### PR TITLE
Alternaive installation for pip (pip3) and fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Python-Skript für die Realtime-Verbindung eines DHT11/22-Sensors mit einer MariaDB auf dem Raspberry Pi 4.
 
 ## Vorrausetzungen
+
 - Python 3.x
 - GitHub CLI
 - maybe pip3
@@ -12,6 +13,7 @@ Python-Skript für die Realtime-Verbindung eines DHT11/22-Sensors mit einer Mari
 ## Installation
 
 ### 1. MariaDB Server
+
 Installation des MariaDB-Servers auf Debian-Geräten:
 
 ```bash
@@ -27,12 +29,19 @@ Installation von pip3:
 sudo apt install python3-pip
 ```
 
+Alter**naiv**e Installation von pip (pip3):
+
+```bash
+pip install pip
+```
+
 Installation der Bibliotheken mit pip:
 
 ```bash
 pip3 install adafruit-circuitpython-dht
 pip3 install mysql-connector-python
 ```
+
 ### 3. Repo klonen
 
 ```bash
@@ -78,7 +87,6 @@ als letztes beten das es funktioniert und abfahrt:
 ```bash
 python3 script.py
 ```
-
 
 ### Anmerkungen
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Installation von pip3:
 sudo apt install python3-pip
 ```
 
-Alter**naiv**e Installation von pip (pip3):
+Alter**naiv**e Installation von [pip](https://pypi.org/project/pip/) (pip3):
 
 ```bash
 pip install pip

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Python-Skript für die Realtime-Verbindung eines DHT11/22-Sensors mit einer Mari
 
 ## Vorrausetzungen
 - Python 3.x
-- Github CLI
-- mybe pip3
+- GitHub CLI
+- maybe pip3
 
 ## Installation
 


### PR DESCRIPTION
## Pull Request: Readme-Erweiterung - Elegante Pip-Installation mit Eigenhilfe

**Eleganz in Aktion:**

Sie könnten `pip` mit nur einem einzigen Befehl installieren:

```
pip install pip
```

Einfach, oder? Diese selbstreferenzielle Eleganz optimiert und vereinfacht den Workflow.

**Vorteile:**

- **Schlank und schnell:** Eliminiert `ensurepip` und beschleunigt die Installation.
- **Prägnant und raffiniert:** Einzigartige Lösung, die die Essenz von Python verkörpert.
- **Grenzen verschieben:** Fördert Innovation und treibt die Python-Paketverwaltung voran.

**Natürlich achten ich auf Sorgfalt:**

Diese Methode ist offiziell von PyPI unterstützt ([https://pypi.org/project/pip/](https://pypi.org/project/pip/)). Sie wird erfahrenen sowie unerfahrenen Entwicklern eine bessere Möglichkeit geben, Wasabi ich denke, dass es eine gute Erweiterung für die Readme ist.